### PR TITLE
Remove ts-ignore comments

### DIFF
--- a/src/components/D3Node/NodeMenu.tsx
+++ b/src/components/D3Node/NodeMenu.tsx
@@ -352,19 +352,18 @@ const NodeMenu: React.FC<NodeMenuProps> = observer(({treeChartState}) => {
         }, 650);
     }
 
-    // @ts-ignore
     function handleReplaceNode(nodeToRemove: D3Node) {
         if (!nodeToRemove.parent) {
             message.error('根节点无法删除').then(r => r);
             return;
         }
 
-        const nodesEnter = gRef.select<SVGGElement>(`#node-${nodeToRemove.data.scriptId}`);
+        const nodesEnter = gRef.select<SVGGElement, D3Node>(`#node-${nodeToRemove.data.scriptId}`);
         // 视图上移除和这个节点相关的node 和link
         nodesEnter.transition().duration(500)
             .style('opacity', 0)
             .attr("transform", `translate(${nodeToRemove.parent!.y},${nodeToRemove.parent!.x})`)
-            .on('end', function () {
+            .on('end', function (this: SVGGElement) {
                 d3.select(this).remove(); // 在动画结束后移除节点
             });
 
@@ -390,12 +389,12 @@ const NodeMenu: React.FC<NodeMenuProps> = observer(({treeChartState}) => {
             })
 
 
-            const nodesEnter = gRef.select<SVGGElement>(`#node-${firstChild.data.scriptId}`);
+            const nodesEnter = gRef.select<SVGGElement, D3Node>(`#node-${firstChild.data.scriptId}`);
 
             nodesEnter.transition()
                 .duration(650)
                 // .style('opacity', 1)
-                .attrTween("transform", function (d): (t: number) => string {
+                .attrTween("transform", function (d: D3Node): (t: number) => string {
 
                     const interpolateSourceX = d3.interpolate(d.x, nodeToRemove.x);
                     const interpolateSourceY = d3.interpolate(d.y, nodeToRemove.y);

--- a/src/components/editor/style/groovy-language-definition-for-monaco.ts
+++ b/src/components/editor/style/groovy-language-definition-for-monaco.ts
@@ -238,8 +238,10 @@ export const registerGroovyLanguageForMonaco = (monaco: Monaco) => {
                 [/(\{)(\d+(?:,\d*)?)(\})/, ["regexp.escape.control", "regexp.escape.control", "regexp.escape.control"]],
                 [
                     /(\[)(\^?)(?=(?:[^\]\\/]|\\.)+)/,
-                    // @ts-ignore
-                    ["regexp.escape.control", {token: "regexp.escape.control", next: "@regexrange"}],
+                    [
+                        "regexp.escape.control",
+                        {token: "regexp.escape.control", next: "@regexrange"} as languages.IMonarchLanguageAction,
+                    ],
                 ],
                 [/(\()(\?:|\?=|\?!)/, ["regexp.escape.control", "regexp.escape.control"]],
                 [/[()]/, "regexp.escape.control"],
@@ -247,8 +249,10 @@ export const registerGroovyLanguageForMonaco = (monaco: Monaco) => {
                 [/[^\\/]/, "regexp"],
                 [/@regexpesc/, "regexp.escape"],
                 [/\\\./, "regexp.invalid"],
-                // @ts-ignore
-                [/(\/)([gimsuy]*)/, [{token: "regexp", bracket: "@close", next: "@pop"}, "keyword.other"]],
+                [
+                    /(\/)([gimsuy]*)/,
+                    [{token: "regexp", bracket: "@close", next: "@pop"} as languages.IMonarchLanguageAction, "keyword.other"],
+                ],
             ],
 
             regexrange: [

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -13,5 +13,8 @@ declare global {
         updateWorkflowNameApiPath: string;
         listWorkflowsApiPath: string;
         getWorkflowMetadataApiPath: string;
+        MonacoEnvironment?: {
+            getWorker(_: string, label: string): Worker;
+        };
     }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,8 +29,7 @@ import "monaco-editor/esm/vs/editor/contrib/comment/browser/comment"
  */
 
 self.MonacoEnvironment = {
-    // @ts-ignore
-    getWorker: function (_: any, label: string) {
+    getWorker: function (_: string, label: string): Worker | undefined {
 
         if (label === 'json') {
             return new jsonWorker()
@@ -38,6 +37,7 @@ self.MonacoEnvironment = {
         //editorWorkerService
         // 如果默认的worker diff 的小红点会失效。
         // return new editorWorker()
+        return undefined
     },
 }
 


### PR DESCRIPTION
## Summary
- add global typing for `MonacoEnvironment`
- clean up `handleReplaceNode` implementation
- tighten regexp rule types for Groovy definition
- type the Monaco worker initialization

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: JSX elements implicitly have type 'any' in WorkflowMenu.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6874781934088333a90ab0db7c732b6a